### PR TITLE
Containerize the project

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,17 @@
+https://localhost, http://localhost {
+	route /* {
+		reverse_proxy frontend:3000
+	}
+
+	route /api/bulletin/ {
+		reverse_proxy bulletin:8080
+	}
+
+	route /api/course_information/ {
+		reverse_proxy course-information:8080
+	}
+
+	route /api/professor-service/ {
+		reverse_proxy professor-rating:8080
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,28 @@
-# Created by JP Park
-# Last maintained by JP Park
-
-version: '1.0'
-
 services:
-  config-server:
-    image: # TODO
-    container_name: # TODO
+  proxy:
+    image: docker.io/caddy:alpine
     ports:
-      - # TODO
-    environment:
+      - 8080:80
+      - 8443:443
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
 
-
-  eureka-server:
-    image: # TODO
-    container_name: # TODO
+  frontend:
+    build: ./frontend
     ports:
-      - # TODO
-    environment:
+      - 3000:8080
 
-  api-gateway:
-    image: # TODO
-    container_name: # TODO
-    ports:
-      - # TODO
+  bulletin:
+    build: ./services/bulletin
+
+  course-information:
+    build: ./services/course-information
+
+  coursicle:
+    build: ./services/coursicle
+
+  optimize:
+    build: ./services/optimize
+
+  professor-rating:
+    build: ./services/professor-rating

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,51 @@
+FROM docker.io/node:current-alpine as base
+
+# Install dependencies only when needed
+FROM base AS deps
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add --no-cache libc6-compat
+WORKDIR /app
+
+# Install dependencies based on the preferred package manager
+COPY package.json pnpm-lock.yaml ./
+RUN corepack enable pnpm && pnpm i --frozen-lockfile
+
+# Rebuild the source code only when needed
+FROM base AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN corepack enable pnpm && pnpm run build
+
+# Production image, copy all the files and run next
+FROM base AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs
+RUN adduser --system --uid 1001 nextjs
+
+# Set the correct permission for prerender cache
+RUN mkdir .next
+RUN chown nextjs:nodejs .next
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  output: "standalone",
+};
 
 export default nextConfig;

--- a/services/bulletin/Dockerfile
+++ b/services/bulletin/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/maven:3-eclipse-temurin-21-alpine as base
+WORKDIR /app
+
+# deps
+COPY pom.xml ./
+RUN mvn dependency:go-offline
+# work-around for go-offline not downloading all deps (MDEP-82)
+RUN mvn verify --fail-never -Dmaven.test.skip
+
+# build
+COPY src/ src/
+RUN mvn package -Dmaven.test.skip
+
+RUN mv target/*.jar app.jar
+
+CMD ["java", "-jar", "app.jar"]

--- a/services/bulletin/src/main/java/edu/uga/devdogs/bulletin/controller/BulletinController.java
+++ b/services/bulletin/src/main/java/edu/uga/devdogs/bulletin/controller/BulletinController.java
@@ -17,6 +17,9 @@ import java.util.List;
 @RequestMapping("/api/bulletin")
 public class BulletinController {
 
+    // Mock class to fix compiler errors -- TODO remove me
+    public static class Course { }
+
     /**
      * Retrieves course information based on the provided course ID.
      *

--- a/services/course-information/Dockerfile
+++ b/services/course-information/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/maven:3-eclipse-temurin-21-alpine as base
+WORKDIR /app
+
+# deps
+COPY pom.xml ./
+RUN mvn dependency:go-offline
+# work-around for go-offline not downloading all deps (MDEP-82)
+RUN mvn verify --fail-never -Dmaven.test.skip
+
+# build
+COPY src/ src/
+RUN mvn package -Dmaven.test.skip
+
+RUN mv target/*.jar app.jar
+
+CMD ["java", "-jar", "app.jar"]

--- a/services/coursicle/Dockerfile
+++ b/services/coursicle/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/maven:3-eclipse-temurin-21-alpine as base
+WORKDIR /app
+
+# deps
+COPY pom.xml ./
+RUN mvn dependency:go-offline
+# work-around for go-offline not downloading all deps (MDEP-82)
+RUN mvn verify --fail-never -Dmaven.test.skip
+
+# build
+COPY src/ src/
+RUN mvn package -Dmaven.test.skip
+
+RUN mv target/*.jar app.jar
+
+CMD ["java", "-jar", "app.jar"]

--- a/services/optimize/Dockerfile
+++ b/services/optimize/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/maven:3-eclipse-temurin-21-alpine as base
+WORKDIR /app
+
+# deps
+COPY pom.xml ./
+RUN mvn dependency:go-offline
+# work-around for go-offline not downloading all deps (MDEP-82)
+RUN mvn verify --fail-never -Dmaven.test.skip
+
+# build
+COPY src/ src/
+RUN mvn package -Dmaven.test.skip
+
+RUN mv target/*.jar app.jar
+
+CMD ["java", "-jar", "app.jar"]

--- a/services/professor-rating/Dockerfile
+++ b/services/professor-rating/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker.io/maven:3-eclipse-temurin-21-alpine as base
+WORKDIR /app
+
+# deps
+COPY pom.xml ./
+RUN mvn dependency:go-offline
+# work-around for go-offline not downloading all deps (MDEP-82)
+RUN mvn verify --fail-never -Dmaven.test.skip
+
+# build
+COPY src/ src/
+RUN mvn package -Dmaven.test.skip
+
+RUN mv target/*.jar app.jar
+
+CMD ["java", "-jar", "app.jar"]

--- a/services/professor-rating/src/main/java/edu/uga/devdogs/professor_rating/controllers/RESTController.java
+++ b/services/professor-rating/src/main/java/edu/uga/devdogs/professor_rating/controllers/RESTController.java
@@ -56,6 +56,7 @@ public class RESTController {
     public double getAggregateHelpfulnessRating(@RequestParam(required = true) String professorName, @RequestParam(required = false) String className) {
 	// return arbitraryMethodName();
 	return 2.0;
+    }
 
     /**
      * Handles GET requests for returning whether attendance is mandatory


### PR DESCRIPTION
This PR sets up containerization with Docker. Each service is run in its own container and everything is glued together with a reverse proxy ([Caddy](https://caddyserver.com/)).

To test, go to the repo root and run `docker compose up --build`. The frontend is exposed at [localhost:8080](http://localhost:8080) (for HTTP) and [localhost:8443](https://localhost:8443) (for HTTPS).

Services that don't currently expose endpoints were not added to the reverse proxy configuration.

This PR _does not_ fix runtime issues with the services. I only made sure that they are in a compilable state. Several of the services currently crash when they're run. I am not fixing that.