### PR TITLE
Created initial scraping methods for syllabus download

### DIFF
--- a/services/professor-rating/pom.xml
+++ b/services/professor-rating/pom.xml
@@ -61,6 +61,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.18.1</version>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/AspNetData.java
+++ b/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/AspNetData.java
@@ -1,0 +1,65 @@
+/**
+ * Class stores data for hidden aspx values that are required in the body of the post request
+ */
+public class AspNetData {
+    private String viewState;
+    private String viewStateGenerator;
+    private String eventValidation;
+
+    /**
+     * Constructor that
+     * @param viewState hidden view state input
+     * @param viewStateGenerator hidden state generator input
+     * @param eventValidation hidden validation input
+     */
+    public AspNetData(String viewState, String viewStateGenerator, String eventValidation) {
+        this.viewState = viewState;
+        this.viewStateGenerator = viewStateGenerator;
+        this.eventValidation = eventValidation;
+    }
+
+    /**
+     * @return viewstate
+     */
+    public String getViewState() {
+        return viewState;
+    }
+
+    /**
+     * Set view state
+     * @param viewState the view state
+     */
+    public void setViewState(String viewState) {
+        this.viewState = viewState;
+    }
+
+    /**
+     * @return view state generator
+     */
+    public String getViewStateGenerator() {
+        return viewStateGenerator;
+    }
+
+    /**
+     * Set view state generator
+     * @param viewStateGenerator the view state generator
+     */
+    public void setViewStateGenerator(String viewStateGenerator) {
+        this.viewStateGenerator = viewStateGenerator;
+    }
+
+    /**
+     * @return event validation
+     */
+    public String getEventValidation() {
+        return eventValidation;
+    }
+
+    /**
+     * Set event validation
+     * @param eventValidation the event validation
+     */
+    public void setEventValidation(String eventValidation) {
+        this.eventValidation = eventValidation;
+    }
+}

--- a/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/ClassInfo.java
+++ b/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/ClassInfo.java
@@ -1,0 +1,65 @@
+/**
+ * Class stores information about the course class, which includes professor name, the title, and semester.
+ */
+public class ClassInfo {
+    private String instructorName;
+    private String courseTitle;
+    private String semesterAndYear;
+
+    /**
+     * The data needed to hold class information
+     * @param instructorName the professor name
+     * @param courseTitle the title of the course
+     * @param semesterAndYear the year and semester of when the course was held
+     */
+    public ClassInfo(String instructorName, String courseTitle, String semesterAndYear) {
+        this.instructorName = instructorName;
+        this.courseTitle = courseTitle;
+        this.semesterAndYear = semesterAndYear;
+    }
+
+    /**
+     * @return professor name
+     */
+    public String getInstructorName() {
+        return instructorName;
+    }
+
+    /**
+     * Sets the professor name
+     * @param instructorName professor name
+     */
+    public void setInstructorName(String instructorName) {
+        this.instructorName = instructorName;
+    }
+
+    /**
+     * @return course title
+     */
+    public String getCourseTitle() {
+        return courseTitle;
+    }
+
+    /**
+     * Sets the course title
+     * @param courseTitle the course title
+     */
+    public void setCourseTitle(String courseTitle) {
+        this.courseTitle = courseTitle;
+    }
+
+    /**
+     * @return the semester and year
+     */
+    public String getSemesterAndYear() {
+        return semesterAndYear;
+    }
+
+    /**
+     * Sets the semester and year of the class held
+     * @param semesterAndYear the semester and year
+     */
+    public void setSemesterAndYear(String semesterAndYear) {
+        this.semesterAndYear = semesterAndYear;
+    }
+}

--- a/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/CourseScraper.java
+++ b/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/CourseScraper.java
@@ -1,0 +1,570 @@
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A class that allows users to download syllabus depending on multiple parameters.
+ */
+public class CourseScraper {
+    /**
+     * Scrapes the html of a aspx request in order retrieve hidden values required for post requests
+     * @param html html of aspx request
+     * @return an AspNetData object that holds hidden aspx values
+     */
+    private static AspNetData getAspHiddenData(String html) {
+        Matcher matcher = Pattern
+                .compile("id=\"__VIEWSTATE\" value=\"(.*?)\".*?id=\"__VIEWSTATEGENERATOR\" value=\"(.*?)\".*?id=\"__EVENTVALIDATION\" value=\"(.*?)\"", Pattern.DOTALL)
+                .matcher(html);
+        if (!matcher.find()) return null;
+
+        String viewState = matcher.group(1);
+        String viewStateGenerator = matcher.group(2);
+        String eventValidation = matcher.group(3);
+
+        return new AspNetData(viewState, viewStateGenerator, eventValidation);
+    }
+
+    /**
+     * Downloads every single syllabus from a professor (includes any year as well)
+     * @param department the department of the major (Chemistry, school of computing, etc)
+     * @param instructorName the professor name
+     * @param path the path to where the file should be downloaded (local disk)
+     */
+    public static void downloadAllSyllabusByInstructor( String department,
+                                                        String instructorName,
+                                                        String path) {
+        try {
+            String url = "https://syllabus.uga.edu/Browse.aspx";
+            Connection.Response response = Jsoup.connect(url)
+                    .method(Connection.Method.GET)
+                    .execute();
+
+            AspNetData data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("Button1", "Submit")
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+
+            DepartmentInfo selectedDep = null;
+            Document doc = response.parse();
+            Elements elements = doc.select("#ddlDept > option");
+            for (int i = 1; i < elements.size(); i++) {
+                Element element = elements.get(i);
+                String departmentCode = element.attr("value");
+                String departmentName = element.text();
+
+                if (departmentName.equalsIgnoreCase(department)) {
+                    selectedDep = new DepartmentInfo(departmentCode, departmentName);
+                    break;
+                }
+            }
+
+            if (selectedDep == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "ddlDept")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            //Gets the latest semester
+            doc = response.parse();
+            elements = doc.select("#ddlSemesters > option");
+            Element element = elements.getLast();
+
+            String semesterCode = element.attr("value");
+            String semesterName = element.text();
+            SemesterInfo selectedSemester = new SemesterInfo(semesterCode, semesterName);
+            String defaultSemesterCode = selectedSemester.getSemesterCode();
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "ddlSemesters")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .data("ddlSemesters", defaultSemesterCode)
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .data("ddlSemesters", defaultSemesterCode)
+                    .data("Button_ViewAll", "View+information+for+all+courses+with+Syllabus+files")
+                    .data("ddlCourse", "-1")
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            String html = response.body();
+            List<Integer> downloadInds = new ArrayList<>();
+            doc = response.parse();
+            Elements trTags = doc.select("#gridFileList > tbody > tr");
+            for (int i = 1; i < trTags.size(); i++) {
+                Element trTag = trTags.get(i);
+                Elements tdTags = trTag.select("td");
+
+                ClassInfo info = new ClassInfo(
+                        tdTags.get(0).text(),
+                        tdTags.get(1).text(),
+                        tdTags.get(2).text());
+                if (info.getInstructorName().equalsIgnoreCase(instructorName)) {
+                    downloadInds.add(i - 1);
+                }
+            }
+
+            for (Integer ind : downloadInds)
+            {
+                response = Jsoup.connect(url)
+                        .data("__EVENTTARGET", "gridFileList")
+                        .data("__EVENTARGUMENT", String.format("Select$%d", ind))
+                        .data("__LASTFOCUS", "")
+                        .data("__VIEWSTATE", data.getViewState())
+                        .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                        .data("__VIEWSTATEENCRYPTED", "")
+                        .data("__EVENTVALIDATION", data.getEventValidation())
+                        .data("RadioButtonList1", "DEP")
+                        .data("ddlDept", selectedDep.getDepartmentCode())
+                        .data("ddlSemesters", defaultSemesterCode)
+                        .data("ddlCourse", "-1")
+                        .method(Connection.Method.POST)
+                        .cookies(response.cookies())
+                        .followRedirects(true)
+                        .ignoreContentType(true)
+                        .execute();
+
+                String contentDisposition = response.header("Content-disposition");
+                if (contentDisposition == null || contentDisposition.isEmpty()) continue;
+
+                Matcher matcher = Pattern
+                        .compile("filename=\"(.*?)\"")
+                        .matcher(contentDisposition);
+                if (!matcher.find()) continue;
+
+                String fileName = matcher.group(1);
+
+                // output here
+                FileOutputStream  out = new FileOutputStream(new java.io.File(String.format("%s/%s", path, fileName)));
+                out.write(response.bodyAsBytes());          // resultImageResponse.body() is where the image's contents are.
+                out.close();
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Downloads every single syllabus from a professor and specific course title (includes any year as well)
+     * @param department the department of the major (Chemistry, school of computing, etc)
+     * @param courseTitle the title of the course
+     * @param instructorName the professor name
+     * @param path the path to where the file should be downloaded (local disk)
+     */
+    public static void downloadAllSyllabusByInstructorAndCourse( String department,
+                                                                 String courseTitle,
+                                                                 String instructorName,
+                                                                 String path) {
+        try {
+            String url = "https://syllabus.uga.edu/Browse.aspx";
+            Connection.Response response = Jsoup.connect(url)
+                    .method(Connection.Method.GET)
+                    .execute();
+
+            AspNetData data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("Button1", "Submit")
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+
+            DepartmentInfo selectedDep = null;
+            Document doc = response.parse();
+            Elements elements = doc.select("#ddlDept > option");
+            for (int i = 1; i < elements.size(); i++) {
+                Element element = elements.get(i);
+                String departmentCode = element.attr("value");
+                String departmentName = element.text();
+
+                if (departmentName.equalsIgnoreCase(department)) {
+                    selectedDep = new DepartmentInfo(departmentCode, departmentName);
+                    break;
+                }
+            }
+
+            if (selectedDep == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "ddlDept")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            //Gets the latest semester
+            doc = response.parse();
+            elements = doc.select("#ddlSemesters > option");
+            Element element = elements.getLast();
+
+            String semesterCode = element.attr("value");
+            String semesterName = element.text();
+            SemesterInfo selectedSemester = new SemesterInfo(semesterCode, semesterName);
+            String defaultSemesterCode = selectedSemester.getSemesterCode();
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "ddlSemesters")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .data("ddlSemesters", defaultSemesterCode)
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .data("ddlSemesters", defaultSemesterCode)
+                    .data("Button_ViewAll", "View+information+for+all+courses+with+Syllabus+files")
+                    .data("ddlCourse", "-1")
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            String html = response.body();
+            List<Integer> downloadInds = new ArrayList<>();
+            doc = response.parse();
+            Elements trTags = doc.select("#gridFileList > tbody > tr");
+            for (int i = 1; i < trTags.size(); i++) {
+                Element trTag = trTags.get(i);
+                Elements tdTags = trTag.select("td");
+
+                ClassInfo info = new ClassInfo(
+                        tdTags.get(0).text(),
+                        tdTags.get(1).text(),
+                        tdTags.get(2).text());
+                if (info.getCourseTitle().equalsIgnoreCase(courseTitle) &&
+                        info.getInstructorName().equalsIgnoreCase(instructorName)) {
+                    downloadInds.add(i - 1);
+                }
+            }
+
+            for (Integer ind : downloadInds)
+            {
+                response = Jsoup.connect(url)
+                        .data("__EVENTTARGET", "gridFileList")
+                        .data("__EVENTARGUMENT", String.format("Select$%d", ind))
+                        .data("__LASTFOCUS", "")
+                        .data("__VIEWSTATE", data.getViewState())
+                        .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                        .data("__VIEWSTATEENCRYPTED", "")
+                        .data("__EVENTVALIDATION", data.getEventValidation())
+                        .data("RadioButtonList1", "DEP")
+                        .data("ddlDept", selectedDep.getDepartmentCode())
+                        .data("ddlSemesters", defaultSemesterCode)
+                        .data("ddlCourse", "-1")
+                        .method(Connection.Method.POST)
+                        .cookies(response.cookies())
+                        .followRedirects(true)
+                        .ignoreContentType(true)
+                        .execute();
+
+                String contentDisposition = response.header("Content-disposition");
+
+                if (contentDisposition == null || contentDisposition.isEmpty()) continue;
+                Matcher matcher = Pattern
+                        .compile("filename=\"(.*?)\"")
+                        .matcher(contentDisposition);
+
+                if (!matcher.find()) continue;
+
+
+                String fileName = matcher.group(1);
+
+                // output here
+                FileOutputStream  out = new FileOutputStream(new java.io.File(String.format("%s/%s", path, fileName)));
+                out.write(response.bodyAsBytes());          // resultImageResponse.body() is where the image's contents are.
+                out.close();
+
+                int i = 0;
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     *
+     * @param department the department of the major (Chemistry, school of computing, etc)
+     * @param courseTitle the title of the course
+     * @param path the path to where the file should be downloaded (local disk)
+     */
+    public static void downloadAllSyllabusByCourse(  String department,
+                                                     String courseTitle,
+                                                     String path) {
+        try {
+            String url = "https://syllabus.uga.edu/Browse.aspx";
+            Connection.Response response = Jsoup.connect(url)
+                    .method(Connection.Method.GET)
+                    .execute();
+
+            AspNetData data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("Button1", "Submit")
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+
+            DepartmentInfo selectedDep = null;
+            Document doc = response.parse();
+            Elements elements = doc.select("#ddlDept > option");
+            for (int i = 1; i < elements.size(); i++) {
+                Element element = elements.get(i);
+                String departmentCode = element.attr("value");
+                String departmentName = element.text();
+
+                if (departmentName.equalsIgnoreCase(department)) {
+                    selectedDep = new DepartmentInfo(departmentCode, departmentName);
+                    break;
+                }
+            }
+
+            if (selectedDep == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "ddlDept")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            //Gets the latest semester
+            doc = response.parse();
+            elements = doc.select("#ddlSemesters > option");
+            Element element = elements.getLast();
+
+            String semesterCode = element.attr("value");
+            String semesterName = element.text();
+            SemesterInfo selectedSemester = new SemesterInfo(semesterCode, semesterName);
+            String defaultSemesterCode = selectedSemester.getSemesterCode();
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "ddlSemesters")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .data("ddlSemesters", defaultSemesterCode)
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            response = Jsoup.connect(url)
+                    .data("__EVENTTARGET", "")
+                    .data("__EVENTARGUMENT", "")
+                    .data("__LASTFOCUS", "")
+                    .data("__VIEWSTATE", data.getViewState())
+                    .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                    .data("__VIEWSTATEENCRYPTED", "")
+                    .data("__EVENTVALIDATION", data.getEventValidation())
+                    .data("RadioButtonList1", "DEP")
+                    .data("ddlDept", selectedDep.getDepartmentCode())
+                    .data("ddlSemesters", defaultSemesterCode)
+                    .data("Button_ViewAll", "View+information+for+all+courses+with+Syllabus+files")
+                    .data("ddlCourse", "-1")
+                    .method(Connection.Method.POST)
+                    .cookies(response.cookies())
+                    .followRedirects(true)
+                    .execute();
+
+            data = getAspHiddenData(response.body());
+            if (data == null) return;
+
+            String html = response.body();
+            List<Integer> downloadInds = new ArrayList<>();
+            doc = response.parse();
+            Elements trTags = doc.select("#gridFileList > tbody > tr");
+            for (int i = 1; i < trTags.size(); i++) {
+                Element trTag = trTags.get(i);
+                Elements tdTags = trTag.select("td");
+
+                ClassInfo info = new ClassInfo(
+                        tdTags.get(0).text(),
+                        tdTags.get(1).text(),
+                        tdTags.get(2).text());
+                if (info.getCourseTitle().equalsIgnoreCase(courseTitle)) {
+                    downloadInds.add(i - 1);
+                }
+            }
+
+            for (Integer ind : downloadInds)
+            {
+                response = Jsoup.connect(url)
+                        .data("__EVENTTARGET", "gridFileList")
+                        .data("__EVENTARGUMENT", String.format("Select$%d", ind))
+                        .data("__LASTFOCUS", "")
+                        .data("__VIEWSTATE", data.getViewState())
+                        .data("__VIEWSTATEGENERATOR", data.getViewStateGenerator())
+                        .data("__VIEWSTATEENCRYPTED", "")
+                        .data("__EVENTVALIDATION", data.getEventValidation())
+                        .data("RadioButtonList1", "DEP")
+                        .data("ddlDept", selectedDep.getDepartmentCode())
+                        .data("ddlSemesters", defaultSemesterCode)
+                        .data("ddlCourse", "-1")
+                        .method(Connection.Method.POST)
+                        .cookies(response.cookies())
+                        .followRedirects(true)
+                        .ignoreContentType(true)
+                        .execute();
+
+                String contentDisposition = response.header("Content-disposition");
+                if (contentDisposition == null || contentDisposition.isEmpty()) continue;
+
+                Matcher matcher = Pattern
+                        .compile("filename=\"(.*?)\"")
+                        .matcher(contentDisposition);
+                if (!matcher.find()) continue;
+
+                String fileName = matcher.group(1);
+
+                // output here
+                FileOutputStream  out = new FileOutputStream(new java.io.File(String.format("%s/%s", path, fileName)));
+                out.write(response.bodyAsBytes());          // resultImageResponse.body() is where the image's contents are.
+                out.close();
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/CourseScraper.java
+++ b/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/CourseScraper.java
@@ -200,7 +200,7 @@ public class CourseScraper {
 
                 // output here
                 FileOutputStream  out = new FileOutputStream(new java.io.File(String.format("%s/%s", path, fileName)));
-                out.write(response.bodyAsBytes());          // resultImageResponse.body() is where the image's contents are.
+                out.write(response.bodyAsBytes());         
                 out.close();
             }
 
@@ -381,7 +381,7 @@ public class CourseScraper {
 
                 // output here
                 FileOutputStream  out = new FileOutputStream(new java.io.File(String.format("%s/%s", path, fileName)));
-                out.write(response.bodyAsBytes());          // resultImageResponse.body() is where the image's contents are.
+                out.write(response.bodyAsBytes());          
                 out.close();
 
                 int i = 0;
@@ -559,7 +559,7 @@ public class CourseScraper {
 
                 // output here
                 FileOutputStream  out = new FileOutputStream(new java.io.File(String.format("%s/%s", path, fileName)));
-                out.write(response.bodyAsBytes());          // resultImageResponse.body() is where the image's contents are.
+                out.write(response.bodyAsBytes());          
                 out.close();
             }
 

--- a/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/DepartmentInfo.java
+++ b/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/DepartmentInfo.java
@@ -1,0 +1,50 @@
+/**
+ * Class holds information about each of the school's department and its following code.
+ * The code is to identify which option to select, and the name is the name of the department.
+ * Right now, everything requires a department name, but maybe we can add a static map that holds
+ * the corresponding class course code (ex. CSCI) with its prefix (CS)
+ */
+public class DepartmentInfo {
+    private String departmentCode;
+    private String departmentName;
+
+    /**
+     * The data needed to hold the department information
+     * @param departmentCode code to identify which option to select on the UGA syllabus site
+     * @param departmentName name of the department
+     */
+    public DepartmentInfo(String departmentCode, String departmentName) {
+        this.departmentCode = departmentCode;
+        this.departmentName = departmentName;
+    }
+
+    /**
+     * @return the department code
+     */
+    public String getDepartmentCode() {
+        return departmentCode;
+    }
+
+    /**
+     * Sets the department code
+     * @param departmentCode the department code
+     */
+    public void setDepartmentCode(String departmentCode) {
+        this.departmentCode = departmentCode;
+    }
+
+    /**
+     * @return the department name
+     */
+    public String getDepartmentName() {
+        return departmentName;
+    }
+
+    /**
+     * Sets the department name
+     * @param departmentName the department name
+     */
+    public void setDepartmentName(String departmentName) {
+        this.departmentName = departmentName;
+    }
+}

--- a/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/SemesterInfo.java
+++ b/services/professor-rating/src/main/java/edu/uga/devdogs/syllabus_scraper/SemesterInfo.java
@@ -1,0 +1,26 @@
+public class SemesterInfo {
+    private String semesterCode;
+    private String semesterName;
+
+    public SemesterInfo(String semesterCode, String semesterName) {
+        this.semesterCode = semesterCode;
+        this.semesterName = semesterName;
+    }
+
+    public String getSemesterCode() {
+        return semesterCode;
+    }
+
+    public void setSemesterCode(String semesterCode) {
+        this.semesterCode = semesterCode;
+    }
+
+    public String getSemesterName() {
+        return semesterName;
+    }
+
+    public void setSemesterName(String semesterName) {
+        this.semesterName = semesterName;
+    }
+}
+


### PR DESCRIPTION
The course scraper allows downloading of syllabus depending on what the user wants. However, you need to supply the department name (ex. Chemistry, School of Computing). Also, the methods currently download the file to your local disk. I can change it so that it returns raw data so that the frontend can download it from a buffer stream.