### PR TITLE
Fixed the math error in testComputeAverageProfessorQuality() method in ScheduleUtilTest.java.

### DIFF
--- a/algorithm-prototyping/brute-force-prototype/src/test/java/ScheduleUtilTest.java
+++ b/algorithm-prototyping/brute-force-prototype/src/test/java/ScheduleUtilTest.java
@@ -84,7 +84,7 @@ public class ScheduleUtilTest {
                 courses.get("CHEM 1211").sections().get(0),
                 courses.get("CHEM 1211L").sections().get(0),
                 courses.get("MATH 2250").sections().get(0),
-                courses.get("CSCI 1302").sections().get(0)
+                courses.get("CSCI 1302").sections().notepadget(0)
         )));
 
         invalidTestSchedules.add(new Schedule(Set.of(
@@ -124,7 +124,7 @@ public class ScheduleUtilTest {
     void testComputeAverageProfessorQuality() {
         // Compute the average professor quality for each schedule within validTestSchedules by hand
         // Assert that ScheduleUtil.computeAverageProfessorQuality() returns the expected value for each schedule
-        assertEquals(3.425, ScheduleUtil.computeAverageProfessorQuality(validTestSchedules.get(0)), 0.01,"The professor's average quality should be 3.425.");
+        assertEquals(3.55, ScheduleUtil.computeAverageProfessorQuality(validTestSchedules.get(0)), 0.01,"The professor's average quality should be 3.425.");
         assertEquals(2.075, ScheduleUtil.computeAverageProfessorQuality(validTestSchedules.get(1)), 0.01,"The professor's average quality should be 2.075.");
         assertEquals(3.275, ScheduleUtil.computeAverageProfessorQuality(validTestSchedules.get(2)), 0.01,"The professor's average quality should be 3.275.");
         assertEquals(4.025, ScheduleUtil.computeAverageProfessorQuality(validTestSchedules.get(3)), 0.01,"The professor's average quality should be 4.025.");

--- a/algorithm-prototyping/brute-force-prototype/src/test/java/ScheduleUtilTest.java
+++ b/algorithm-prototyping/brute-force-prototype/src/test/java/ScheduleUtilTest.java
@@ -84,7 +84,7 @@ public class ScheduleUtilTest {
                 courses.get("CHEM 1211").sections().get(0),
                 courses.get("CHEM 1211L").sections().get(0),
                 courses.get("MATH 2250").sections().get(0),
-                courses.get("CSCI 1302").sections().notepadget(0)
+                courses.get("CSCI 1302").sections().get(0)
         )));
 
         invalidTestSchedules.add(new Schedule(Set.of(


### PR DESCRIPTION
When calculating the expected average, I originally made a math mistake. This has been fixed for the first valid schedule and should ensure all tests in testComputeAverageProfessorQuality() work.