### PR TITLE
renamed endpoint to 'getCoursesByMajor()'

### DIFF
--- a/services/course-information/src/main/java/edu/uga/devdogs/course_information/controller/CourseInfoController.java
+++ b/services/course-information/src/main/java/edu/uga/devdogs/course_information/controller/CourseInfoController.java
@@ -91,7 +91,7 @@ public class CourseInfoController {
     })
     @GetMapping("/coursesByMajor")
     @Tag(name="course-information")
-    public ResponseEntity<List<Course>> getCourseList(@RequestParam String major) {
+    public ResponseEntity<List<Course>> getCoursesByMajor(@RequestParam String major) {
 
         //return 400 for empty major
         if (major.isEmpty()) {


### PR DESCRIPTION
I renamed one of the GET endpoints in the course information rest controller from "getCourseList()" to "getCoursesByMajor()" so that the name more accurately reflects what the endpoint actually does.