### PR TITLE
Optimize method "Overload"ing

### DIFF
--- a/algorithm-prototyping/brute-force-prototype/src/main/java/edu/uga/devdogs/bruteforceprototype/BruteForcePrototype.java
+++ b/algorithm-prototyping/brute-force-prototype/src/main/java/edu/uga/devdogs/bruteforceprototype/BruteForcePrototype.java
@@ -19,34 +19,34 @@ public class BruteForcePrototype {
      *
      * @param inputCourses a set of requested courses to generate an optimal schedule from
      * @param distances a nested string map that represents distances between buildings on campus
-     * @param weights an array of floats representing the weights for each objective
      * @param softConstraints the soft constraints on the schedule
      * @param hardConstraints the hard constraints on the schedule
      * @return the output of optimize()
      */
-    public static int[][] algorithmDriver(Set<Course> inputCourses, Map<String, Map<String, Double>> distances, double[] weights, SConstraints softConstraints, HConstraints hardConstraints){
+    public static int[][] algorithmDriver(Set<Course> inputCourses, Map<String, Map<String, Double>> distances,
+                                          SConstraints softConstraints, HConstraints hardConstraints){
         Set<Course> outputCourses = new HashSet<>(inputCourses);
 
         try {
             outputCourses = BruteForceUtil.dataPreHardFilter(outputCourses, hardConstraints);
         } catch (Exception e) {
             System.out.println(e.getMessage());
-            // If this try block is cought, that means there is an impossible schedule based on the hard constraints
-            // Therefore, the algorithmDriver resturns null instead of computing a schedule.
+            // If this try block is caught, that means there is an impossible schedule based on the hard constraints
+            // Therefore, the algorithmDriver returns null instead of computing a schedule.
             return null;
         }
 
         try {
             outputCourses = BruteForceUtil.dataPreSoftFilter(outputCourses, softConstraints);
             //outputCourses = BruteForceUtil.dayOfWeekConvert(outputCourses);
-            return optimize(outputCourses, distances, weights);
+            return optimize(outputCourses, distances, softConstraints,false);
         } catch (Exception e){
             // If an exception arises from dataPreSoftFilter, we will call an overloaded version of optimize().
             // The overloaded version is not written yet, so when it is actually implemented,
             // this catch block will need updated accordingly.
             System.out.println(e.getMessage());
             //outputCourses = BruteForceUtil.dayOfWeekConvert(outputCourses);
-            return optimize(outputCourses, distances, weights, softConstraints);
+            return optimize(outputCourses, distances, softConstraints, true);
         }
     }
 
@@ -60,10 +60,10 @@ public class BruteForcePrototype {
      *
      * @param inputCourses a set of courses to generate an optimal schedule from
      * @param distances a nested string map that represents distances between buildings on campus
-     * @param weights an array of floats representing the weights for each objective
      * @return the five schedules with the highest overall objective score based on the input courses and weights
      */
-    public static int[][] optimize(Set<Course> inputCourses, Map<String, Map<String, Double>> distances,  double[] weights) {
+    public static int[][] optimize(Set<Course> inputCourses, Map<String, Map<String, Double>> distances,
+                                   SConstraints soft, boolean usesSoft) {
         Set<Schedule> validSchedules = generateValidSchedules(inputCourses);
 
         if (validSchedules.isEmpty()){
@@ -83,8 +83,12 @@ public class BruteForcePrototype {
         // Insert time is O(n), so *technically* merge sort is faster, but this function is not called frequently, so
         // Readability matters much more than performance here.
         for (Schedule schedule : validSchedules) {
-            double overallObjective = ScheduleUtil.computeOverallObjective(schedule, distances, weights);
-
+            double overallObjective = 0;
+            if (usesSoft) {
+                overallObjective = ScheduleUtil.computeOverallObjectiveExtended(schedule, distances, soft);
+            } else {
+                overallObjective = ScheduleUtil.computeOverallObjective(schedule, distances);
+            }
             // Starting from the back of the array, find where the new schedule belongs based on overallObjective.
             int i = sortedSchedules.size();
             while (i != 0 && overallObjective > sortedOverallObjectives.get(i-1)) {

--- a/algorithm-prototyping/brute-force-prototype/src/main/java/edu/uga/devdogs/bruteforceprototype/schedule/ScheduleUtil.java
+++ b/algorithm-prototyping/brute-force-prototype/src/main/java/edu/uga/devdogs/bruteforceprototype/schedule/ScheduleUtil.java
@@ -1,5 +1,6 @@
 package edu.uga.devdogs.bruteforceprototype.schedule;
 
+import edu.uga.devdogs.sampledataparser.records.SConstraints;
 import edu.uga.devdogs.sampledataparser.records.Section;
 import edu.uga.devdogs.sampledataparser.records.Class;
 
@@ -167,22 +168,13 @@ public class ScheduleUtil {
      *
      * @param schedule the schedule to evaluate
      * @param distances a nested string map that represents distances between buildings on campus
-     * @param weights an array of floats representing the weights for each objective;
-     *                must be of length 3 and add to 1.0
-     *                weights[0] corresponds to averageProfessorQuality
-     *                weights[1] corresponds to maxDistance
-     *                weights[2] corresponds to averageIdleTime
      *
      * @return the overall objective score for the schedule
      */
-    public static double computeOverallObjective(Schedule schedule, Map<String, Map<String, Double>> distances, double[] weights) {
+    public static double computeOverallObjective(Schedule schedule, Map<String, Map<String, Double>> distances) {
        // Checks if the parameters are valid
-       if (schedule == null || distances == null || weights == null) {
+       if (schedule == null || distances == null) {
            throw new IllegalArgumentException("Parameters cannot be null");
-       } else if (weights.length != 3) {
-           throw new IllegalArgumentException("Number of weights must be 3");
-       } else if (Math.abs(weights[0] + weights[1] + weights[2] - 1) > 1e-6) {
-           throw new IllegalArgumentException("The sum of the weights must be equal to 1");
        }
 
         // The minimum rating on rate my professor is 1.0(if they have ratings).
@@ -205,8 +197,67 @@ public class ScheduleUtil {
 
         // computes the weighted sum. normalizedMaxDistance and normalizedAverageIdleTime are being subtracted from 1 since
         // the higher the value, the worse the schedule.
-        return normalizedProfessorQuality * weights[0] + (1 - normalizedMaxDistance) * weights[1] + (1 - normalizedAverageIdleTime) * weights[2];
+        return normalizedProfessorQuality / 3 + (1 - normalizedMaxDistance) / 3 + (1 - normalizedAverageIdleTime) / 3;
     }
+
+    public static double computeOverallObjectiveExtended(Schedule schedule, Map<String, Map<String, Double>> distances, SConstraints softConstraints) {
+        // Checks if the parameters are valid
+        if (schedule == null || distances == null) {
+            throw new IllegalArgumentException("Parameters cannot be null");
+        }
+
+        // The minimum rating on rate my professor is 1.0(if they have ratings).
+        final double professorQualityMinimum = 1.0;
+        // The maximum rating on rate my professor is 5.0
+        final double professorQualityMaximum = 5.0;
+        // The minimum distance between classes is 0.0 if they are in the same building.
+        final double maxDistanceMinimum = 0.0;
+        // The highest distance shown in the document is 22.1, so 30 should be a good maximum for calculations.
+        final double maxDistanceMaximum = 30.0;
+        // The minimum average idle time is 0 which should only happen if the person has one class a day.
+        final double averageIdleTimeMinimum = 0;
+        // The earliest a class can start is 8:00 a.m. and latest a class can go is 9:00 p.m. which is 780 minutes between those times.
+        final double averageIdleTimeMaximum = 780;
+
+        // The Earliest a class can start is 8 am and the latest a class can start is 9 pm.
+        final double prefTimeMinimum = 8.0;
+        final double prefTimeMaximum = 21.0;
+
+
+        // finds the values and then plugs them into the normalize function with the minimum and maximum.
+        double normalizedProfessorQuality = normalizeValue(computeAverageProfessorQuality(schedule), professorQualityMinimum, professorQualityMaximum);
+        double normalizedMaxDistance = normalizeValue(computeMaxDistance(schedule, distances), maxDistanceMinimum, maxDistanceMaximum);
+        double normalizedAverageIdleTime = normalizeValue(computeAverageIdleTime(schedule), averageIdleTimeMinimum, averageIdleTimeMaximum);
+
+        // Taking an average of all the optional softConstraints and then multiply the average by 0.25.
+        double possSConstraintScore = 0;
+        int possSConstraintsCount = 0;
+
+        if (softConstraints.gapDay() != null) {
+            possSConstraintScore += computeGapDay(schedule, softConstraints.gapDay()) ? 1 : 0;
+            possSConstraintsCount++;
+        }
+        if (softConstraints.prefStartTime() != null) {
+            possSConstraintScore += normalizeValue(computeStartTime(schedule), prefTimeMinimum, prefTimeMaximum);;
+            possSConstraintsCount++;
+        }
+        if (softConstraints.prefEndTime() != null) {
+            possSConstraintScore += 1 - normalizeValue(computeEndTime(schedule), prefTimeMinimum, prefTimeMaximum);
+            possSConstraintsCount++;
+        }
+
+        // Takes the sum and divides it by number of summed values, checks for when count = 0 so we don't divide by 0
+        possSConstraintScore = possSConstraintsCount == 0 ? 0 : possSConstraintScore / possSConstraintsCount;
+
+        // computes the weighted sum. normalizedMaxDistance and normalizedAverageIdleTime are being subtracted from 1 since
+        // the higher the value, the worse the schedule.
+        double output = normalizedProfessorQuality / 4 + (1 - normalizedMaxDistance) / 4;
+        output += (1 - normalizedAverageIdleTime) / 4;
+        output += (possSConstraintScore / 4);
+
+        return output;
+    }
+
 
     /**
      * Normalizes the values using min-max normalization and clips outliers


### PR DESCRIPTION
Removed the double weights[] parameter from every method since we are not accepting input weights, but generating them inside the methods.

Fixed a couple grammar typos in comments

Made computeOverallObjectiveExtended which includes optional softConstraints such as gapDay, prefEndTime and prefStartTime in weights. 

Added a boolean operator to optimize instead of an overload to the method. This is because if we were to overload, we would be adding 70 lines of duplicate code just to call a different function on 1 line. Instead, the boolean parameter will determine which computeOverallObjective function is called.

closes #541 