### PR TITLE
Updated SemesterList

### DIFF
--- a/frontend/src/components/survey/QuestionnaireForm.tsx
+++ b/frontend/src/components/survey/QuestionnaireForm.tsx
@@ -117,6 +117,28 @@ export const QuestionnareForm = ({ className }: Props) => {
     `Spring ${new Date().getFullYear() + 1}`,
     `Summer ${new Date().getFullYear() + 1}`,
   ];
+  
+  //This will change the semester list based on the current month
+  // For Janurary: (Spring of this year, Summer of this year, Fall of this year)
+  if ((new Date().getMonth() == 0)) {
+    semesterList[0] = `Spring ${new Date().getFullYear()}`;
+    semesterList[1] = `Summer ${new Date().getFullYear()}`;
+    semesterList[2] = `Fall ${new Date().getFullYear()}`;
+
+  // For Feburary - May: (Summer of this year, Fall of this year, Spring of next year)
+  } else if (new Date().getMonth() < 5) {
+    semesterList[0] = `Summer ${new Date().getFullYear()}`;
+    semesterList[1] = `Fall ${new Date().getFullYear()}`;
+    semesterList[2] = `Spring ${new Date().getFullYear() + 1}`;
+
+  // For September - December: (Spring of next year, Summer of next year, Fall of next year)
+  } else if (new Date().getMonth() > 7) {
+    semesterList[0] = `Spring ${new Date().getFullYear() +1}`;
+    semesterList[1] = `Summer ${new Date().getFullYear()+1}`;
+    semesterList[2] = `Fall ${new Date().getFullYear()+1}`;
+    //alert(`the month is ${testDay.getMonth()}`);
+  }
+
   const creditHoursList = Array.from({ length: 18 }, (_, i) =>
     (i + 1).toString().padStart(2, "0"),
   );


### PR DESCRIPTION
Updated semester selection dropdown to change the order and years of the options based on the user's current month. For January: (Spring of this year, Summer of this year, Fall of this year), For February - May: (Summer of this year, Fall of this year, Spring of next year), For September - December: (Spring of next year, Summer of next year, Fall of next year). Left functionality the same for June - August.