### PR TITLE
tweaked getCoordinates endpoint

### DIFF
--- a/services/course-information/src/main/java/edu/uga/devdogs/course_information/controller/CourseInfoController.java
+++ b/services/course-information/src/main/java/edu/uga/devdogs/course_information/controller/CourseInfoController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -546,7 +547,8 @@ public class CourseInfoController {
         }
         try {
             // Coordinates of a building number as a string
-            List<String> coordinates = CourseInformationService.getCoordinatesByBuildingNumber(buildingNumber);
+            List<String> coordinates = new ArrayList<String>();
+            coordinates.add(courseInformationService.getCoordinatesByBuildingNumber(buildingNumber));
 
             // Return the list of subject strings if found
             return ResponseEntity.ok(coordinates);


### PR DESCRIPTION
I modified the getCoordinatesByBuildingNumber() endpoint so it correctly returns a list containing one String (the coordinates for the building).