### PR TITLE
fixed lopsided 'generate' button space

### DIFF
--- a/frontend/src/app/course-adding/page.tsx
+++ b/frontend/src/app/course-adding/page.tsx
@@ -13,7 +13,7 @@ export default function Courses() {
     <div className="min-h-screen">
       <Navbar />
       {/* Wrapper for the two headings, Add Courses, Couse Display, and Search Filter components */}
-      <div className="px-4 pb-32 pt-8 md:px-12 lg:px-24">
+      <div className="px-4 pb-4 pt-8 md:px-12 lg:px-24">
         <div className="flex flex-col gap-8">
           <div className="flex flex-col gap-8 md:flex-row">
             <div className="w-full md:w-2/3">


### PR DESCRIPTION
does what it says on the tin.

<img width="480" alt="Screenshot 2025-03-10 at 6 24 20 PM" src="https://github.com/user-attachments/assets/197e5b2c-00cc-4ff5-b502-182a96352472" />
