### PR TITLE
New Styling for Schedule View

### DIFF
--- a/frontend/src/app/schedules/page.tsx
+++ b/frontend/src/app/schedules/page.tsx
@@ -16,7 +16,7 @@ export default function SchedulePage() {
 
   // Map colors to course (if the course includes a lab, drop the L from the string)
   const colorMapping: { [key: string]: string } = {};
-  const usedColors: Set<string | undefined> = new Set();
+  const usedColors: Set<string> = new Set();
 
   function getBgColorForClass(classTitle: string): string {
     // Check if color has already been used
@@ -42,7 +42,7 @@ export default function SchedulePage() {
 
       // Reassign the color to the first class that needs a color
       colorToAssign = bgColors[usedColors.size % bgColors.length];
-      usedColors.add(colorToAssign);
+      usedColors.add(colorToAssign!);
     }
     // If no color assigned
     if (!colorToAssign) {

--- a/frontend/src/app/schedules/page.tsx
+++ b/frontend/src/app/schedules/page.tsx
@@ -15,7 +15,7 @@ export default function SchedulePage() {
   ];
 
   // Map colors to course (if the course includes a lab, drop the L from the string)
-  const colorMapping: { [key: string]: string } = {};
+  const colorMapping: Record<string, string> = {};
   const usedColors: Set<string> = new Set<string>();
 
   function getBgColorForClass(classTitle: string): string {

--- a/frontend/src/app/schedules/page.tsx
+++ b/frontend/src/app/schedules/page.tsx
@@ -16,7 +16,7 @@ export default function SchedulePage() {
 
   // Map colors to course (if the course includes a lab, drop the L from the string)
   const colorMapping: { [key: string]: string } = {};
-  const usedColors: Set<string> = new Set();
+  const usedColors: Set<string> = new Set<string>();
 
   function getBgColorForClass(classTitle: string): string {
     // Check if color has already been used
@@ -42,7 +42,7 @@ export default function SchedulePage() {
 
       // Reassign the color to the first class that needs a color
       colorToAssign = bgColors[usedColors.size % bgColors.length];
-      usedColors.add(colorToAssign!);
+      usedColors.add(colorToAssign!); // ! asserts variable to not be read as undefined
     }
     // If no color assigned
     if (!colorToAssign) {

--- a/frontend/src/app/schedules/page.tsx
+++ b/frontend/src/app/schedules/page.tsx
@@ -6,6 +6,54 @@ import WeekSchedule from "@/components/schedules/WeekSchedule";
 import Link from "next/link";
 
 export default function SchedulePage() {
+  const bgColors = [
+    "bg-[#cc0128]",
+    "bg-[#bc8da7]",
+    "bg-[#0db1b1]",
+    "bg-[#53917e]",
+    "bg-[#202c59]",
+  ];
+
+  // Map colors to course (if the course includes a lab, drop the L from the string)
+  const colorMapping: { [key: string]: string } = {};
+  const usedColors: Set<string | undefined> = new Set();
+
+  function getBgColorForClass(classTitle: string): string {
+    // Check if color has already been used
+    if (colorMapping[classTitle]) {
+      return colorMapping[classTitle];
+    }
+
+    // Find an unused color
+    let colorToAssign: string | undefined;
+
+    // Assign unused color
+    if (usedColors.size < bgColors.length) {
+      for (const color of bgColors) {
+        if (!usedColors.has(color)) {
+          colorToAssign = color;
+          usedColors.add(color); // Mark color as used
+          break;
+        }
+      }
+    } else {
+      // All colors have been used, so reset colors to be reused
+      usedColors.clear();
+
+      // Reassign the color to the first class that needs a color
+      colorToAssign = bgColors[usedColors.size % bgColors.length];
+      usedColors.add(colorToAssign);
+    }
+    // If no color assigned
+    if (!colorToAssign) {
+      colorToAssign = "bg-gray-500";
+    }
+
+    // Store the assign color for classTitle
+    colorMapping[classTitle] = colorToAssign;
+    return colorToAssign;
+  }
+
   const weekScheduleData: WeekScheduleType = {
     Monday: [
       {
@@ -27,7 +75,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-bulldog-red",
+        bgColor: getBgColorForClass("CSCI 3030"),
         borderColor: "border-bulldog-red",
         currentDay: "MW",
         otherTimes: ["F", "8:00 - 8:50 am", "Chemistry 100"],
@@ -51,7 +99,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-bulldog-red",
+        bgColor: getBgColorForClass("CSCI 1302"),
         borderColor: "border-bulldog-red",
         currentDay: "M",
         otherTimes: ["TR", "9:35 am - 10:50 am", "Food Sci 100"],
@@ -75,7 +123,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-dev-dog-blue",
+        bgColor: getBgColorForClass("BIOL 1103"),
         borderColor: "border-dev-dog-blue",
 
         currentDay: "MWF",
@@ -102,7 +150,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-bulldog-red",
+        bgColor: getBgColorForClass("CSCI 1302"),
         borderColor: "border-bulldog-red",
         currentDay: "TR",
         otherTimes: ["M", "10:20 am - 11:10 am", "Conner 100"],
@@ -127,7 +175,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-lake-herrick",
+        bgColor: getBgColorForClass("MUSI 2300"),
         borderColor: "border-lake-herrick",
         currentDay: "TR",
         otherTimes: ["", "", ""],
@@ -153,7 +201,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-bulldog-red",
+        bgColor: getBgColorForClass("CSCI 3030"),
         borderColor: "border-bulldog-red",
         currentDay: "MW",
         otherTimes: ["F", "8:00 am - 8:50 am", "Chemistry 100"],
@@ -177,7 +225,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-dev-dog-blue",
+        bgColor: getBgColorForClass("BIOL 1103"),
         borderColor: "border-dev-dog-blue",
         currentDay: "MWF",
         otherTimes: ["", "", ""],
@@ -203,7 +251,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-bulldog-red",
+        bgColor: getBgColorForClass("CSCI 1302"),
         borderColor: "border-bulldog-red",
         currentDay: "TR",
         otherTimes: ["M", "10:20 am - 11:10 am", "Conner 100"],
@@ -227,7 +275,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-lake-herrick",
+        bgColor: getBgColorForClass("MUSI 2300"),
         borderColor: "border-lake-herrick",
         currentDay: "TR",
         otherTimes: ["", "", ""],
@@ -251,7 +299,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-dev-dog-blue",
+        bgColor: getBgColorForClass("BIOL 1103"),
         borderColor: "border-dev-dog-blue",
         currentDay: "R",
         otherTimes: ["", "", ""],
@@ -277,7 +325,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-bulldog-red",
+        bgColor: getBgColorForClass("CSCI 3030"),
         borderColor: "border-bulldog-red",
         currentDay: "F",
         otherTimes: ["MW", "8:00 - 8:50 am", "Boyd 100"],
@@ -301,7 +349,7 @@ export default function SchedulePage() {
         openSeats: 100,
         maxSeats: 100,
         waitlist: 0,
-        bgColor: "bg-dev-dog-blue",
+        bgColor: getBgColorForClass("BIOL 1103"),
         borderColor: "border-dev-dog-blue",
         currentDay: "MWF",
         otherTimes: ["", "", ""],

--- a/frontend/src/components/schedules/DayClass.tsx
+++ b/frontend/src/components/schedules/DayClass.tsx
@@ -4,6 +4,27 @@ import { useState, useEffect } from "react";
 
 type DayClassProps = ClassData;
 
+// Convert 12-hours to 24-hours
+function convertToMinutes(time: string): number {
+  const [hour, minute] = time.split(":").map((val) => parseInt(val, 10));
+  const suffix = time.slice(-2).toLowerCase();
+  let convertedTime = hour! * 60 + minute!; // The ! assers the tyoe of hour and minute as number since they could be undefined. If there's an error it means one of these is undefined.
+  if (suffix === "pm" && hour !== 12) {
+    convertedTime += 12 * 60;
+  }
+  if (suffix === "am" && hour === 12) {
+    convertedTime -= 12 * 60;
+  }
+  return convertedTime;
+}
+
+// Duration of course for the day
+function getDuration(timeStart: string, timeEnd: string): number {
+  const startMinutes = convertToMinutes(timeStart);
+  const endMinutes = convertToMinutes(timeEnd);
+  return endMinutes - startMinutes;
+}
+
 // Allows course block info window to resize itself relative to the screen size
 function useResize() {
   const [width, setWidth] = useState("80vw");
@@ -308,6 +329,15 @@ export default function DayClass({
   currentDay,
   otherTimes,
 }: DayClassProps) {
+  // Find course duartion
+  const duration = getDuration(timeStart, timeEnd);
+
+  // Position of class block based on start time
+  const startPosition = `${timeDifference ? `${timeDifference * 0.8}px` : "0px"}`;
+
+  // Height of class block based on duration
+  const classHeight = `${duration * 0.9}px`;
+
   // Open course block info popup
   const [courseBlockClicked, setcourseBlockClicked] = useState(false);
   const courseBlockInfo = () => {
@@ -317,13 +347,23 @@ export default function DayClass({
   return (
     <div className={`relative ${className}`} onClick={courseBlockInfo}>
       <div
-        className={`w-full rounded-lg p-4 transition duration-150 ease-in-out hover:bg-black ${bgColor} flex justify-between`}
+        className="absolute inset-0 border-r-2 bg-gray-100"
+        style={{
+          height: "100%",
+          width: "100%",
+          backgroundSize: "100% 60px",
+        }}
+      ></div>
+
+      <div
+        className={`w-full rounded-lg p-4 transition duration-150 ease-in-out hover:bg-black ${bgColor} flex items-center justify-between`}
         style={{
           position: "absolute",
-          top: timeDifference ? `${timeDifference * 0.9}px` : "0px",
+          top: startPosition, //timeDifference ? `${timeDifference * 0.9}px` : "0px",
+          height: classHeight,
         }}
       >
-        <div className="">
+        <div>
           <h2 className="font-bold text-white">{classTitle}</h2>
           {locationShort && (
             <p className="text-sm text-white/90">{locationShort}</p>

--- a/frontend/src/components/schedules/WeekSchedule.tsx
+++ b/frontend/src/components/schedules/WeekSchedule.tsx
@@ -147,10 +147,6 @@ export default function WeekSchedule({ weekData }: WeekScheduleProps) {
                     new Date(`1970/01/01 ${classData.timeStart}`),
                     new Date("1970/01/01 3:06 pm"), // This time is not correct it should be 8:00 AM, but it positions the course blocks correctly
                   );
-                  const duration = differenceInMinutes(
-                    new Date(`1970/01/01 ${classData.timeEnd}`),
-                    new Date(`1970/01/01 ${classData.timeStart}`),
-                  );
                   return (
                     <DayClass
                       key={`${day}-${classData.classTitle}-${index}`}

--- a/frontend/src/components/schedules/WeekSchedule.tsx
+++ b/frontend/src/components/schedules/WeekSchedule.tsx
@@ -82,6 +82,39 @@ export default function WeekSchedule({ weekData }: WeekScheduleProps) {
     return () => controller.abort();
   }, [handleScroll]);
 
+  /*
+   * Create lines for each hour under each day. (8AM to 10PM)
+   */
+  const createHourlySections = () => {
+    const sections = [];
+    const startHour = 8; // 8AM
+    const endHour = 22; // 10PM
+    const totalHours = endHour - startHour + 1;
+    const sectionHeight = 50 / totalHours;
+    for (let hour = startHour; hour <= endHour; hour++) {
+      // convert 24-hour to am/pm
+      const ampm = hour > 12 ? hour - 12 : hour;
+      const period = hour >= 12 ? "PM" : "AM";
+      const timeString = `${ampm}:00 ${period}`;
+      sections.push(
+        <div
+          key={hour}
+          className="h- relative w-full border-t border-gray-300"
+          style={{
+            height: `${sectionHeight}%`,
+            top: `${(hour - startHour) * sectionHeight}%`,
+            zIndex: 0, // lines stay behind course blocks
+          }}
+        >
+          <span className="absolute left-0 px-4 text-sm text-gray-500">
+            {timeString}
+          </span>
+        </div>,
+      );
+    }
+    return sections;
+  };
+
   return (
     <div className="relative z-0 mx-auto w-screen max-w-[1800px] overflow-hidden px-8">
       <button
@@ -96,26 +129,36 @@ export default function WeekSchedule({ weekData }: WeekScheduleProps) {
       </button>
 
       <section
-        className="grid h-[540px] w-full snap-x snap-mandatory grid-cols-[1rem_repeat(5,calc((100%-1rem)/var(--cols)))] overflow-x-auto scroll-smooth [--cols:1] sm:[--cols:2] md:overflow-hidden lg:[--cols:3] xl:[--cols:4] 2xl:[--cols:5]"
+        className="scroll-smoothp-1 m-2 grid h-[750px] w-full snap-x snap-mandatory grid-cols-[1rem_repeat(5,calc((100%-1rem)/var(--cols)))] overflow-x-auto rounded-lg bg-pink-200/50 p-4 [--cols:1] sm:[--cols:2] md:overflow-hidden lg:[--cols:3] xl:[--cols:4] 2xl:[--cols:5]"
         ref={scrollportRef}
       >
         <div />
 
         {Object.entries(weekData).map(([day, classes]) => (
           <div className="snap-end snap-always pr-4" data-title={day} key={day}>
-            <article className="flex h-full w-full flex-col gap-4 rounded-xl bg-pink-200/50 px-4 py-6">
-              <h2 className="text text-xl font-bold">{day}</h2>
-              <div>
-                {classes.map((classData, index) => (
-                  <DayClass
-                    key={`${day}-${classData.classTitle}-${index}`}
-                    {...classData}
-                    timeDifference={differenceInMinutes(
-                      new Date(`1970/01/01 ${classData.timeStart}`),
-                      new Date("1970/01/01 8:00 am"),
-                    )}
-                  />
-                ))}
+            <article className="flex h-full w-full flex-col gap-4 rounded-xl bg-white px-0 py-0">
+              <h2 className="text rounded-lg bg-[#222233] px-4 py-3 text-center text-xl font-bold text-white">
+                {day}
+              </h2>
+              <div className="relative h-full">
+                {createHourlySections()}
+                {classes.map((classData, index) => {
+                  const startDiff = differenceInMinutes(
+                    new Date(`1970/01/01 ${classData.timeStart}`),
+                    new Date("1970/01/01 3:06 pm"), // This time is not correct it should be 8:00 AM, but it positions the course blocks correctly
+                  );
+                  const duration = differenceInMinutes(
+                    new Date(`1970/01/01 ${classData.timeEnd}`),
+                    new Date(`1970/01/01 ${classData.timeStart}`),
+                  );
+                  return (
+                    <DayClass
+                      key={`${day}-${classData.classTitle}-${index}`}
+                      {...classData}
+                      timeDifference={startDiff}
+                    />
+                  );
+                })}
               </div>
             </article>
           </div>


### PR DESCRIPTION
Made the changes as requested in #568.

- Made each day's heading match the nabber.
- Each course is assigned a color from a palate defined as an array of background colors. 
    - The color for the course is mapped to the course title (ex. CSCI 4300). If there's a lab drop the L from the course for the color to match with the course lecture.
    - The colors will repeat after they've all been used if another course is added.
- Course details are still displayed when you click them.

- When adding the lines and time spacing for the blocks the start time on the WeekSchedule.tsx file has 3:06 PM which is not 8AM as it should be, but it provides the correct spacing.
- The lines for each hour are spaced by the total number of hours. I reduced the size of the course blocks by about half which is why 50 is divided by total hours in WeekSchedule.tsx.

<img width="1388" alt="Schedule Screen 1" src="https://github.com/user-attachments/assets/13854134-87f6-474a-a6c0-d5eba85b81b0" />
<img width="1384" alt="Schedule Screen 2" src="https://github.com/user-attachments/assets/0fcb5d5f-1be6-4c1b-b8cd-0791181a8d43" />
