### PR TITLE
Removed Modify and Shuffle Buttons + Updated Front Page Design

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,19 +13,28 @@ export default function Home() {
   return (
     <>
       <Navbar />
-      <div className="relative -mt-[3.625rem] flex flex-1 flex-col items-center justify-center gap-16 px-4 pt-24 text-center">
-        <div className="flex flex-col items-center px-6 py-8 min-[480px]:px-12 sm:px-16 md:max-w-[80%] lg:max-w-[60%]">
-          <div className="flex w-full flex-col items-center">
-            <div className="flex justify-center text-6xl md:text-7xl xl:text-8xl">
+      <div
+        className="relative -mt-[3.625rem] flex h-[calc(100vh-100px)] flex-1 flex-col items-center justify-center gap-16 overflow-hidden px-4 pt-24 text-center"
+        style={{
+          backgroundImage: `url(${background.src})`,
+          backgroundSize: "cover",
+          backgroundPosition: "bottom",
+          backgroundRepeat: "no-repeat",
+          backgroundAttachment: "fixed",
+        }}
+      >
+        <div className="flex flex-col items-center px-6 py-8 min-[480px]:px-12 sm:px-16 md:max-w-[80%]">
+          <div className="flex w-full flex-col items-center rounded-3xl bg-gradient-to-b from-white/50 to-transparent p-8 backdrop-blur-sm">
+            <div className="flex translate-y-5 justify-center text-nowrap text-6xl md:text-7xl xl:translate-y-3 xl:text-[5rem]">
               <h2 className="font-extrabold text-slate-800">Bulldog Planner</h2>
             </div>
 
-            <div className="flex w-full flex-col items-center">
+            <div className="flex w-full flex-col items-center pl-10 pr-10">
               <div className="flex w-full items-center justify-center gap-8">
-                <div className="flex flex-col items-start">
+                <div className="flex translate-x-5 flex-col items-start">
                   <div className="flex items-start">
                     <div className="mr-4 h-20 border-l-4 border-bulldog-red"></div>
-                    <div className="flex flex-col">
+                    <div className="flex h-20 flex-col justify-center text-nowrap">
                       <span className="text-left text-2xl font-bold leading-tight text-bulldog-red sm:text-3xl xl:text-4xl">
                         An Optimized
                         <br />
@@ -39,19 +48,18 @@ export default function Home() {
                 </div>
                 <Image
                   alt="UGA Dev Dogs logo"
-                  className="flex-shrink-0"
                   height={220}
                   width={220}
                   src={devdogCobranded}
                 />
               </div>
 
-              <div className="flex w-full max-w-lg items-center justify-center text-xl font-bold xl:text-2xl">
+              <div className="flex w-full max-w-lg -translate-y-5 items-center justify-center text-xl font-bold xl:-translate-y-3 xl:text-2xl">
                 <p className="-mr-8 w-1/2 cursor-default rounded-l-full bg-[#F8E6EA] bg-dusty-pink px-6 py-5 text-left text-neutral-600/40">
                   Ready?
                 </p>
                 <Link
-                  className="flex w-3/5 items-center gap-4 rounded-full bg-bulldog-red px-6 py-5 pl-8 pr-1.5 text-white shadow-md"
+                  className="flex w-3/5 items-center rounded-full bg-bulldog-red px-6 py-5 pl-8 pr-1.5 text-white shadow-md"
                   href="/create"
                 >
                   Start Now!{" "}

--- a/frontend/src/app/schedules/layout.tsx
+++ b/frontend/src/app/schedules/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <>
-      <Navbar keyword={"schedules"} />
+      <Navbar />
       {children}
     </>
   );


### PR DESCRIPTION
finally removed modify and shuffle buttons, but I haven't finished checking all the sites with the different backgrounds yet. I updated the frontpage to have the background tho.

#670.

progress on #680 (not yet done).

<img width="1551" alt="Frontpage Update" src="https://github.com/user-attachments/assets/526106b7-8051-4083-8468-5283c575b351" />
<img width="1551" alt="Schedules Page Nav Buttons Removed" src="https://github.com/user-attachments/assets/320a9856-50d9-4d4a-9390-9af9f6cced67" />
