### PR TITLE
fixed path for algorithm endpoint

### DIFF
--- a/services/course-information/src/main/java/edu/uga/devdogs/course_information/controller/CourseInfoController.java
+++ b/services/course-information/src/main/java/edu/uga/devdogs/course_information/controller/CourseInfoController.java
@@ -372,12 +372,12 @@ public class CourseInfoController {
      * @param walking Whether to consider walking time between classes
      * @return returns a list of lists of integers representing recommended CRNs
      */
-    @Operation(summary = "get section by crn", description = "Returns a list of recommended CRNS based on input parameters.")
+    @Operation(summary = "get recommended schedules", description = "Returns a list of recommended CRNS based on input parameters.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Sections found"),
             @ApiResponse(responseCode = "500", description = "Internal server error")
     })
-    @GetMapping("/section-by-crn")
+    @GetMapping("/get-recommended-schedules")
     @Tag(name="course-information")
     public ResponseEntity<List<List<Integer>>> getRecommendedSchedules(List<Integer> inputCourseCrns, String gapDay, int prefStartTime, int prefEndTime, boolean showFilledClasses,
     List<Integer> excludedCourseCrns, List<Integer> excludedSectionCrns, String inputCampus, int minCreditHours, int maxCreditHours, boolean walking) {


### PR DESCRIPTION
Changed the path for the getRecommendedSchedules endpoint to /get-recommended-schedules so it won't conflict with another endpoint. Also changed the summary in the operation annotation to accurately describe what the endpoint does.