### PR TITLE
Restored Plan Deletion Functionality (+prettier)

### DIFF
--- a/frontend/src/app/plans/page.tsx
+++ b/frontend/src/app/plans/page.tsx
@@ -78,7 +78,7 @@ export default function MyPlans() {
               <SavedPlan
                 plan={plan}
                 onPin={() => pinPlan(plan.id)}
-                onDelete={() => confirmDeletePlan(plan.id)}
+                onDelete={() => confirmDeletePlan(plan.title)}
               />
             </motion.div>
           ))}


### PR DESCRIPTION
Probably the single easiest bug fix I've ever done. :)

Just changed the deletePlan component (the confirmation popup) to accept the plan's title instead of its ID (which was that weird string we were seeing). The IDs were added to allow the plans to be renamed, since I previously had all of the functions referencing the plans by their titles. All the other functions work with an ID, but the delete function requires the title in order to display it in the confirmation box.


https://github.com/user-attachments/assets/b194c5f4-56c9-48f9-8a35-76d129e289fb

Closes issue #755 

